### PR TITLE
Small api fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ that you are constantly type casting the API and have confirmed that the jQuery
 API allows a specific type of object to be provided as a parameter, send a pull
 request to add that API enhancement.
 
+jQuery allows two types of elements, HTML elements and SVG elements. This API
+wrapper is biased towards HTML manipulation so you will see that for map/filter/each
+the HTMLElement has been used as a parameter or return value versus the more
+generic Element. This design choice is based on the desire to make HTML
+element manipulation better supported at the expense of the less common SVG
+scenario.
+
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ then enjoy the types available in `org.scalajs.jquery`.
 scalajs-jquery 0.6 is built and published for Scala.js 0.5.0 and following in
 the 0.5.x series, with both Scala 2.10 and 2.11.
 
+The API was generated automatically. The API often uses js.Any where other more
+specific types could be used but scala's type checking will prevent. In some cases
+you will need to cast to the appropriate type to allow compilation to succeed.
+jQuery allows many different types of parameters for the same function. If you find
+that you are constantly type casting the API and have confirmed that the jQuery
+API allows a specific type of object to be provided as a parameter, send a pull
+request to add that API enhancement.
+
+
 License
 -------
 

--- a/src/main/scala/org/scalajs/jquery/JQuery.scala
+++ b/src/main/scala/org/scalajs/jquery/JQuery.scala
@@ -176,8 +176,10 @@ trait JQueryStatic extends js.Object {
   var browser: JQueryBrowserInfo = _
   var support: JQuerySupport = _
   def contains(container: Element, contained: Element): Boolean = ???
-  def each(collection: js.Any, callback: js.Function2[Int, HTMLElement, Any]): js.Dynamic = ???
-  def each(collection: js.Any, callback: js.ThisFunction0[js.Any, Any]): js.Dynamic = ???
+  def each[A](collection: js.Array[A], callback: js.Function2[Int, A, _]): Unit
+  def each[A](collection: js.Array[A], callback: js.ThisFunction0[A, _]): Unit
+  def each[A](collection: js.Dictionary[A], callback: js.Function2[String, A, _]): Unit
+  def each[A](collection: js.Dictionary[A], callback: js.ThisFunction0[A, _]): Unit
   def extend(target: js.Any, objs: js.Any*): Object = ???
   def extend(deep: Boolean, target: js.Any, objs: js.Any*): Object = ???
   def globalEval(code: String): js.Dynamic = ???
@@ -191,8 +193,10 @@ trait JQueryStatic extends js.Object {
   def isWindow(obj: js.Any): Boolean = ???
   def isXMLDoc(node: Node): Boolean = ???
   def makeArray(obj: js.Any): js.Array[js.Any] = ???
-  def map(array: js.Array[js.Any], callback: js.Function2[Int, HTMLElement, Any]): js.Array[Any] = ???
-  def map(array: js.Array[js.Any], callback: js.Function1[Int, Any]): js.Array[Any] = ???
+  def map[A, B](collection: js.Array[A], callback: js.Function2[A, Int, B]): js.Array[B]
+  def map[A, B](collection: js.Array[A], callback: js.Function1[A, B]): js.Array[B]
+  def map[A, B](collection: js.Dictionary[A], callback: js.Function2[A, String, B]): js.Dictionary[B]
+  def map[A, B](collection: js.Dictionary[A], callback: js.Function1[A, B]): js.Dictionary[B]
   def merge(first: js.Array[js.Any], second: js.Array[js.Any]): js.Array[js.Any] = ???
   def noop(): js.Dynamic = ???
   def now(): Double = ???
@@ -451,9 +455,8 @@ trait JQuery extends js.Object {
   def wrapAll(wrappingElement: js.Any): JQuery = ???
   def wrapInner(wrappingElement: js.Any): JQuery = ???
   def wrapInner(func: js.Function1[js.Any, js.Any]): JQuery = ???
-  def each(func: js.Function2[Int, HTMLElement, Any]): JQuery = ???
-  def each(func: js.Function1[Int, Any]): JQuery = ???
-  def each(func: js.ThisFunction0[js.Any, Any]): JQuery = ???
+  def each(func: js.Function2[Int, HTMLElement, _]): JQuery = ???
+  def each(func: js.ThisFunction0[HTMLElement, _]): JQuery = ???
   def get(index: Int): js.Dynamic = ???
   def get(): js.Dynamic = ???
   def index(selectorOrElement: js.Any): Int = ???
@@ -480,8 +483,8 @@ trait JQuery extends js.Object {
   def end(): JQuery = ???
   def eq(index: Int): JQuery = ???
   def filter(selector: String): JQuery = ???
-  def filter(func: js.Function2[Int, HTMLElement, js.Any]): JQuery = ???
-  def filter(func: js.Function1[Int, js.Any]): JQuery = ???
+  def filter(func: js.Function2[Int, HTMLElement, Boolean]): JQuery = ???
+  def filter(func: js.ThisFunction0[HTMLElement, Boolean]): JQuery = ???
   def filter(element: js.Any): JQuery = ???
   def filter(obj: JQuery): JQuery = ???
   def find(selector: String): JQuery = ???
@@ -495,9 +498,8 @@ trait JQuery extends js.Object {
   def is(element: js.Any): Boolean = ???
   def is(obj: JQuery): Boolean = ???
   def last(): JQuery = ???
-  def map(callback: js.Function2[Int, HTMLElement, Any]): JQuery = ???
-  def map(callback: js.Function1[Int, Any]): JQuery = ???
-  def map(callback: js.ThisFunction0[js.Any, Any]): JQuery = ???
+  def map[B](callback: js.Function2[Int, HTMLElement, B]): JQuery = ???
+  def map[B](callback: js.ThisFunction0[HTMLElement, B]): JQuery = ???
   def next(selector: String): JQuery = ???
   def next(): JQuery = ???
   def nextAll(selector: String): JQuery = ???

--- a/src/main/scala/org/scalajs/jquery/JQuery.scala
+++ b/src/main/scala/org/scalajs/jquery/JQuery.scala
@@ -41,7 +41,7 @@ trait JQueryAjaxSettings extends js.Object {
   var xhrFields: js.Any = _
 }
 
-trait JQueryXHR extends XMLHttpRequest {
+trait JQueryXHR extends XMLHttpRequest with JQueryPromise {
   def overrideMimeType(): js.Dynamic = ???
 }
 
@@ -176,7 +176,8 @@ trait JQueryStatic extends js.Object {
   var browser: JQueryBrowserInfo = _
   var support: JQuerySupport = _
   def contains(container: Element, contained: Element): Boolean = ???
-  def each(collection: js.Any, callback: js.Function2[js.Any, js.Any, js.Any]): js.Dynamic = ???
+  def each(collection: js.Any, callback: js.Function2[Int, HTMLElement, Any]): js.Dynamic = ???
+  def each(collection: js.Any, callback: js.ThisFunction0[js.Any, Any]): js.Dynamic = ???
   def extend(target: js.Any, objs: js.Any*): Object = ???
   def extend(deep: Boolean, target: js.Any, objs: js.Any*): Object = ???
   def globalEval(code: String): js.Dynamic = ???
@@ -190,7 +191,8 @@ trait JQueryStatic extends js.Object {
   def isWindow(obj: js.Any): Boolean = ???
   def isXMLDoc(node: Node): Boolean = ???
   def makeArray(obj: js.Any): js.Array[js.Any] = ???
-  def map(array: js.Array[js.Any], callback: js.Function2[js.Any, js.Any, js.Any]): js.Array[js.Any] = ???
+  def map(array: js.Array[js.Any], callback: js.Function2[Int, HTMLElement, Any]): js.Array[Any] = ???
+  def map(array: js.Array[js.Any], callback: js.Function1[Int, Any]): js.Array[Any] = ???
   def merge(first: js.Array[js.Any], second: js.Array[js.Any]): js.Array[js.Any] = ???
   def noop(): js.Dynamic = ???
   def now(): Double = ???
@@ -449,7 +451,9 @@ trait JQuery extends js.Object {
   def wrapAll(wrappingElement: js.Any): JQuery = ???
   def wrapInner(wrappingElement: js.Any): JQuery = ???
   def wrapInner(func: js.Function1[js.Any, js.Any]): JQuery = ???
-  def each(func: js.Function2[js.Any, Element, js.Any]): JQuery = ???
+  def each(func: js.Function2[Int, HTMLElement, Any]): JQuery = ???
+  def each(func: js.Function1[Int, Any]): JQuery = ???
+  def each(func: js.ThisFunction0[js.Any, Any]): JQuery = ???
   def get(index: Int): js.Dynamic = ???
   def get(): js.Dynamic = ???
   def index(selectorOrElement: js.Any): Int = ???
@@ -476,7 +480,8 @@ trait JQuery extends js.Object {
   def end(): JQuery = ???
   def eq(index: Int): JQuery = ???
   def filter(selector: String): JQuery = ???
-  def filter(func: js.Function1[js.Any, js.Any]): JQuery = ???
+  def filter(func: js.Function2[Int, HTMLElement, js.Any]): JQuery = ???
+  def filter(func: js.Function1[Int, js.Any]): JQuery = ???
   def filter(element: js.Any): JQuery = ???
   def filter(obj: JQuery): JQuery = ???
   def find(selector: String): JQuery = ???
@@ -490,7 +495,9 @@ trait JQuery extends js.Object {
   def is(element: js.Any): Boolean = ???
   def is(obj: JQuery): Boolean = ???
   def last(): JQuery = ???
-  def map(callback: js.Function2[js.Any, Element, js.Any]): JQuery = ???
+  def map(callback: js.Function2[Int, HTMLElement, Any]): JQuery = ???
+  def map(callback: js.Function1[Int, Any]): JQuery = ???
+  def map(callback: js.ThisFunction0[js.Any, Any]): JQuery = ???
   def next(selector: String): JQuery = ???
   def next(): JQuery = ???
   def nextAll(selector: String): JQuery = ???


### PR DESCRIPTION
Updated each and map to accept more strongly typed parameters while preserving the existing. Note the use of Any instead of js.Any on the each method to allow returning any value type as the value to optionally stop iteration. The use of Int together with HTMLElement was motivated by the fact that apply(Int) returns an HTMLElement. However, that's not consistently enforced in all of the iteration/index-oriented APIs.

Small modification to allow JQueryXHR to inherit from JQueryPromise as documented in the jQuery API.

Updated documentation a little to help people now to the wrapper library.