### PR TITLE
Return DOM elements instead of js.Dynamic

### DIFF
--- a/src/main/scala/org/scalajs/jquery/JQuery.scala
+++ b/src/main/scala/org/scalajs/jquery/JQuery.scala
@@ -451,8 +451,8 @@ trait JQuery extends js.Object {
   def wrapInner(wrappingElement: js.Any): JQuery = js.native
   def wrapInner(func: js.Function1[js.Any, js.Any]): JQuery = js.native
   def each(func: js.Function2[js.Any, Element, js.Any]): JQuery = js.native
-  def get(index: Int): js.Dynamic = js.native
-  def get(): js.Dynamic = js.native
+  def get(index: Int): Element = js.native
+  def get(): js.Array[Element] = js.native
   def index(selectorOrElement: js.Any): Int = js.native
   def index(): Int = js.native
   var length: Int = js.native


### PR DESCRIPTION
As [documented here](http://api.jquery.com/get/), the `get` method on a jQuery object always return a DOM element.

Here's a small modification to the facade to acknowledge that.