### PR TITLE
Explicit jquery path to avoid class path ambiguity

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies +=
   "org.scala-js" %%% "scalajs-dom" % "0.8.0"
 
 jsDependencies +=
-  "org.webjars" % "jquery" % "2.1.3" / "jquery.js"
+  "org.webjars" % "jquery" % "2.1.3" / "2.1.3/jquery.js"
 
 jsDependencies in Test += RuntimeDOM
 


### PR DESCRIPTION
Without this change I get
```
JSLibResolveException: Some references to JS libraries could not be resolved:
- Ambiguous reference to a JS library: jquery.js
  Possible paths found on the classpath:
  - scala/tools/nsc/doc/html/resource/lib/jquery.js
  - META-INF/resources/webjars/jquery/2.1.3/jquery.js
  originating from: root:compile
```

when fullOpting. It looks like it is because ```org.scala-lang:scala-compiler:2.11.6``` is pulled into my shared project in a scala-js + play build. But an extra jquery on the class path seems likely in other scenarios as well.