### PR TITLE
$.attr(String): to return UndefOr[String] instead of plain String

### DIFF
--- a/src/main/scala/org/scalajs/jquery/JQuery.scala
+++ b/src/main/scala/org/scalajs/jquery/JQuery.scala
@@ -215,7 +215,7 @@ trait JQuery extends js.Object {
   def serializeArray(): js.Array[js.Any] = js.native
   def addClass(classNames: String): JQuery = js.native
   def addClass(func: js.Function2[js.Any, js.Any, JQuery]): js.Dynamic = js.native
-  def attr(attributeName: String): String = js.native
+  def attr(attributeName: String): js.UndefOr[String] = js.native
   def attr(attributeName: String, value: js.Any): JQuery = js.native
   def attr(map: js.Any): JQuery = js.native
   def attr(attributeName: String, func: js.Function2[js.Any, js.Any, js.Any]): JQuery = js.native


### PR DESCRIPTION
Fixes #18.
Without this change, .attr(String) throws ClassCastException on every inexisting attribute:
```
jQuery(document.body).attr("data-inexisting")

Uncaught scala.scalajs.runtime.UndefinedBehaviorError:
  An undefined behavior was detected:
  undefined is not an instance of java.lang.String

$throwClassCastException @	scalajsenv.js:99
$as_T                    @	stuff-fastopt.js:18193
...
```

Works for me.