### PR TITLE
Add notes on using scala-js-jquery with Scala.js bundler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Next define a `jquery` object in your Scala code using the `@JSImport` annotatio
 A simple example on how to use the Scala.js JQuery facade this way is shown here:
 
 ```
-package app
-
 import org.scalajs.jquery.JQueryStatic
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
@@ -57,8 +55,7 @@ import scala.scalajs.js.annotation.JSImport
 object jquery extends JQueryStatic
 
 object Main extends js.JSApp {
-
-  @scala.scalajs.js.annotation.JSExport
+  @js.annotation.JSExport
   override def main(): Unit = {
     jquery("body").html("Hello world!")
   }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,53 @@ If you want it to be included in the final `client-jsdeps.js`, you can add the d
     jsDependencies +=
       "org.webjars" % "jquery" % "2.1.3" / "2.1.3/jquery.js"
 
+Using [Scala.js Bundler](https://scalacenter.github.io/scalajs-bundler)
+-----------------------------------------------------------------------
+
+If you want to use Scala.js Bundler (SBT plugin must be enabled in `project/plugins.sbt`) to import jQuery as npm module, then add the following lines to your sbt build definition:
+
+```
+enablePlugins(ScalaJSBundlerPlugin)
+
+libraryDependencies += "be.doeraene" %%% "scalajs-jquery" % "0.9.1"
+
+npmDependencies in Compile ++= Seq(
+  "jquery" -> "2.1.3"
+)
+```
+
+Next define a `jquery` object in your Scala code using the @JSImport annotation to get access to the exported `jQuery` object.
+
+```
+@js.native
+@JSImport("jquery", JSImport.Namespace)
+object jquery extends JQueryStatic
+```
+
+You can access the Scala.js JQuery facade using
+
+```
+package app
+
+import org.scalajs.jquery.JQueryStatic
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("jquery", JSImport.Namespace)
+object jquery extends JQueryStatic
+
+object Main extends js.JSApp {
+
+  @scala.scalajs.js.annotation.JSExport
+  override def main(): Unit = {
+    jquery("body").html("Hello world!")
+  }
+}
+```
+
+Running the SBT task ``fastOptJS::webpack`` will generate a Javascript bundle (`...-fastopt-bundle.js`) including jquery as specified in the `npmDependencies` sbt build definition setting.
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want it to be included in the final `client-jsdeps.js`, you can add the d
 Using [Scala.js Bundler](https://scalacenter.github.io/scalajs-bundler)
 -----------------------------------------------------------------------
 
-If you want to use Scala.js Bundler (SBT plugin must be enabled in `project/plugins.sbt`) to import jQuery as npm module, then add the following lines to your sbt build definition:
+If you want to use Scala.js Bundler (sbt plugin must be enabled in `project/plugins.sbt`) to import jQuery as npm module, then add the following lines to your sbt build definition:
 
 ```
 enablePlugins(ScalaJSBundlerPlugin)
@@ -42,15 +42,8 @@ npmDependencies in Compile ++= Seq(
 )
 ```
 
-Next define a `jquery` object in your Scala code using the @JSImport annotation to get access to the exported `jQuery` object.
-
-```
-@js.native
-@JSImport("jquery", JSImport.Namespace)
-object jquery extends JQueryStatic
-```
-
-You can access the Scala.js JQuery facade using
+Next define a `jquery` object in your Scala code using the `@JSImport` annotation to get access to the exported `jQuery` object.
+A simple example on how to use the Scala.js JQuery facade this way is shown here:
 
 ```
 package app
@@ -72,7 +65,7 @@ object Main extends js.JSApp {
 }
 ```
 
-Running the SBT task ``fastOptJS::webpack`` will generate a Javascript bundle (`...-fastopt-bundle.js`) including jquery as specified in the `npmDependencies` sbt build definition setting.
+Running the sbt task `fastOptJS::webpack` will generate a JavaScript bundle (`...-fastopt-bundle.js`) including jquery as specified in the `npmDependencies` sbt build definition setting.
 
 License
 -------


### PR DESCRIPTION
Hi,
I've given Scala.js bundler a try to manage `scala-js-jquery`'s Javascript dependencies. Everything worked nicely and I thought I'll share my findings by adding a little section on Scala.js bundler to the README file.
Cheers,
Manfred